### PR TITLE
Add support for exporting trained models to ONNX and TorchScript, validate runtime differences, and provide examples for deployment on CPU-only systems

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,64 +1,120 @@
-#!/bin/bash
-# Clean Python project artifacts and OS cruft (safe-ish).
-# Usage: DRY_RUN=1 ./clean.sh  # to preview
+#!/usr/bin/env bash
+# ✨ clean.sh — HYPERGLAM repo detox (macOS + Python) ✨
+# Usage:
+#   DRY_RUN=1 ./clean.sh    # preview
+#   ./clean.sh              # actually delete
+#
+# Notes:
+# - Safe-ish: skips .git and never touches outside project root.
+# - Fixes your main bug: rmrf isn't visible inside `find -exec bash -c ...` subshells.
 
-set -euo pipefail
+set -Eeuo pipefail
 
-echo "✨ Cleaning up Python project clutter... ✨"
 DRY_RUN="${DRY_RUN:-0}"
+FIND_ROOT="."
+
+say()  { printf '%b\n' "$*"; }
+ok()   { say "✅ $*"; }
+info() { say "✨ $*"; }
+warn() { say "⚠️  $*"; }
 
 rmrf() {
   if [[ "$DRY_RUN" == "1" ]]; then
-    printf '🧹 (dry-run) %s\n' "$*"
+    printf '🧹 (dry-run) rm -rf %q\n' "$@"
   else
-    printf '🧹 %s\n' "$*"
-    rm -rf "$@"
+    printf '🧹 rm -rf %q\n' "$@"
+    rm -rf -- "$@"
   fi
 }
 
-# Helpers to run find safely (skip .git)
-FIND_ROOT="."
-SKIP_GIT='-not -path "./.git/*"'
+# Delete files (via find) with glam output + dry-run support
+find_del_files() {
+  local root="$1"; shift
+  if [[ ! -e "$root" ]]; then
+    return 0
+  fi
 
-# Python bytecode & caches
-find "$FIND_ROOT" $SKIP_GIT -type d -name "__pycache__" -prune -exec bash -c 'rmrf "$@"' _ {} + 2>/dev/null
-find "$FIND_ROOT" $SKIP_GIT -type f \( -name "*.py[co]" -o -name "*.pyd" \) -print -delete
+  if [[ "$DRY_RUN" == "1" ]]; then
+    # print what would be deleted
+    find "$root" -path "./.git" -prune -o -path "./.git/*" -prune -o \
+      -type f "$@" -print 2>/dev/null \
+      | sed 's/^/🧹 (dry-run) rm -f /'
+  else
+    # print then delete (portable: no -delete surprises)
+    find "$root" -path "./.git" -prune -o -path "./.git/*" -prune -o \
+      -type f "$@" -print -exec rm -f -- {} + 2>/dev/null
+  fi
+}
 
-# build/dist/egg-info
+# Delete directories (via find) with glam output + dry-run support
+find_del_dirs() {
+  local root="$1"; shift
+  if [[ ! -e "$root" ]]; then
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    find "$root" -path "./.git" -prune -o -path "./.git/*" -prune -o \
+      -type d "$@" -print 2>/dev/null \
+      | sed 's/^/🧹 (dry-run) rm -rf /'
+  else
+    # Use -prune + -exec rm -rf to reliably delete matching dirs
+    find "$root" -path "./.git" -prune -o -path "./.git/*" -prune -o \
+      -type d "$@" -print -prune -exec rm -rf -- {} + 2>/dev/null
+  fi
+}
+
+info "Cleaning up Python project clutter… (DRY_RUN=$DRY_RUN)"
+
+# --- Python bytecode & caches -------------------------------------------------
+info "Bytecode & caches"
+find_del_dirs "$FIND_ROOT" -name "__pycache__"
+find_del_files "$FIND_ROOT" \( -name "*.py[co]" -o -name "*.pyd" \)
+
+# --- build/dist/egg-info ------------------------------------------------------
+info "Build artifacts"
 for d in ./build ./dist ./docs/_build ./__pypackages__ ./pip-wheel-metadata; do
   [[ -e "$d" ]] && rmrf "$d"
 done
-find "$FIND_ROOT" $SKIP_GIT -type d -name "*.egg-info" -prune -exec bash -c 'rmrf "$@"' _ {} + 2>/dev/null
+find_del_dirs "$FIND_ROOT" -name "*.egg-info"
 
-# test & typing caches
-for d in ./.pytest_cache ./.mypy_cache ./.ruff_cache ./htmlcov ./.coverage; do
+# --- test & typing caches -----------------------------------------------------
+info "Test/typing caches"
+for d in ./.pytest_cache ./.mypy_cache ./.ruff_cache ./htmlcov; do
   [[ -e "$d" ]] && rmrf "$d"
 done
-# coverage files
-find "$FIND_ROOT" $SKIP_GIT -type f \( -name ".coverage" -o -name ".coverage.*" \) -print -delete
+# .coverage can be a file OR a dir; handle both
+[[ -e ./.coverage ]] && rmrf ./.coverage
+find_del_files "$FIND_ROOT" \( -name ".coverage" -o -name ".coverage.*" \)
 
-# virtual envs / env caches (comment out if you want to keep them)
+# --- virtual envs / env caches (optional) ------------------------------------
+info "Virtual envs / caches (optional)"
 for d in ./.venv ./.tox ./.nox ./.cache; do
   [[ -e "$d" ]] && rmrf "$d"
 done
 
-# Jupyter checkpoints
-find "$FIND_ROOT" $SKIP_GIT -type d -name ".ipynb_checkpoints" -prune -exec bash -c 'rmrf "$@"' _ {} + 2>/dev/null
+# --- Jupyter checkpoints ------------------------------------------------------
+info "Jupyter checkpoints"
+find_del_dirs "$FIND_ROOT" -name ".ipynb_checkpoints"
 
-# Sphinx doctrees (if outside _build)
-find ./docs $SKIP_GIT -type d -name ".doctrees" -prune -exec bash -c 'rmrf "$@"' _ {} + 2>/dev/null || true
-find ./docs $SKIP_GIT -type f -name "*.doctree" -print -delete 2>/dev/null || true
+# --- Sphinx doctrees ----------------------------------------------------------
+info "Sphinx doctrees"
+find_del_dirs ./docs -name ".doctrees"
+find_del_files ./docs -name "*.doctree"
 
-# OS cruft
-find "$FIND_ROOT" $SKIP_GIT -type f -name ".DS_Store" -print -delete
-find "$FIND_ROOT" $SKIP_GIT -type f -name "Thumbs.db" -print -delete
-find "$FIND_ROOT" $SKIP_GIT -type f -name "._*" -print -delete
-find "$FIND_ROOT" $SKIP_GIT -type d -name ".Trashes" -prune -exec bash -c 'rmrf "$@"' _ {} + 2>/dev/null
+# --- OS cruft -----------------------------------------------------------------
+info "OS cruft"
+find_del_files "$FIND_ROOT" -name ".DS_Store"
+find_del_files "$FIND_ROOT" -name "Thumbs.db"
+find_del_files "$FIND_ROOT" -name "._*"
+find_del_dirs  "$FIND_ROOT" -name ".Trashes"
 
-# backup/editor swap files
-find "$FIND_ROOT" $SKIP_GIT -type f \( -name "*~" -o -name "*.swp" -o -name "*.bak" \) -print -delete
+# --- backup/editor swap files -------------------------------------------------
+info "Backup/swap files"
+find_del_files "$FIND_ROOT" \( -name "*~" -o -name "*.swp" -o -name "*.bak" \)
 
-# compiled extensions (optional)
-find "$FIND_ROOT" $SKIP_GIT -type f -name "*.so" -print -delete
+# --- compiled extensions (optional) ------------------------------------------
+info "Compiled extensions (optional)"
+find_del_files "$FIND_ROOT" -name "*.so"
 
-echo "✅ Everything Done Under the Sun."
+ok "Everything Done Under the Sun."


### PR DESCRIPTION
Removing dunders so Add support for exporting trained models to ONNX and TorchScript, validate runtime differences, and provide examples for deployment on CPU-only systems